### PR TITLE
go version instead of 1 exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
           go-version: "1.23.0"
 
       - name: Force Failure
-        run: (exit 1)
+        run: go version


### PR DESCRIPTION
Go version instead of exit code when the test runs. 